### PR TITLE
feat(helm): adoption in service-monitor and default limits for pod

### DIFF
--- a/cluster/charts/x-metrics/Chart.yaml
+++ b/cluster/charts/x-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: x-metrics
 description: A Helm chart for x-metrics
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.1.0"
 
 maintainers:

--- a/cluster/charts/x-metrics/templates/servicemonitor.yaml
+++ b/cluster/charts/x-metrics/templates/servicemonitor.yaml
@@ -14,11 +14,11 @@ spec:
     matchNames:
     - {{ .Values.namespace }}
   endpoints:
-  - path: managedmetrics
+  - path: x-metrics
     port: metrics
     scheme: http
     interval: {{ .Values.serviceMonitor.interval }}
   selector:
     matchLabels:
-      app: {{ include "x-metrics.fullname" . }}
+      app.kubernetes.io/name: {{ include "x-metrics.fullname" . }}
 {{- end }}

--- a/cluster/charts/x-metrics/values.yaml
+++ b/cluster/charts/x-metrics/values.yaml
@@ -36,8 +36,8 @@ ingress:
 
 resources:
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 300m
+    memory: 256Mi
   requests:
     cpu: 100m
     memory: 128Mi


### PR DESCRIPTION
reported by @candonov via slack:

- the pod was getting oomkilled, limits and resources were the same in values.yaml , I bumped up the limits
- the servicemonitor path was wrong, I manually edit it to from `managedmetrics` to `x-metrics  `https://github.com/crossplane-contrib/x-metrics/blob/2519787d4a1b279b25c2c83547ec76b5d08b28fd/cluster/charts/x-metrics/templates/servicemonitor.yaml#L17
- updated the selector from app: x-metrics to [app.kubernetes.io/name](http://app.kubernetes.io/name): x-metrics