### PR TITLE
chore: deploy on release.namespace by default

### DIFF
--- a/cluster/charts/x-metrics/templates/_helpers.tpl
+++ b/cluster/charts/x-metrics/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Target namespace
+*/}}
+{{- define "x-metrics.namespace" -}}
+{{- default .Values.namespace .Release.Namespace }}
+{{- end }}

--- a/cluster/charts/x-metrics/templates/leader_election_role.yaml
+++ b/cluster/charts/x-metrics/templates/leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "x-metrics.fullname" . }}-leader-election
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "x-metrics.namespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/cluster/charts/x-metrics/templates/leader_election_role_binding.yaml
+++ b/cluster/charts/x-metrics/templates/leader_election_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "x-metrics.fullname" . }}-leader-election
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "x-metrics.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "x-metrics.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "x-metrics.namespace" . }}

--- a/cluster/charts/x-metrics/templates/role_binding.yaml
+++ b/cluster/charts/x-metrics/templates/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "x-metrics.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "x-metrics.namespace" . }}

--- a/cluster/charts/x-metrics/templates/serviceaccount.yaml
+++ b/cluster/charts/x-metrics/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "x-metrics.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "x-metrics.namespace" . }}
   labels:
     {{- include "x-metrics.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/cluster/charts/x-metrics/templates/servicemonitor.yaml
+++ b/cluster/charts/x-metrics/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-    - {{ .Values.namespace }}
+    - {{ include "x-metrics.namespace" . }}
   endpoints:
   - path: x-metrics
     port: metrics

--- a/cluster/charts/x-metrics/values.yaml
+++ b/cluster/charts/x-metrics/values.yaml
@@ -19,7 +19,7 @@ serviceMonitor:
   labels: {}
   interval: 60s
 
-namespace: x-metrics
+namespace: ""
 
 podAnnotations: {}
 


### PR DESCRIPTION
If .Values.namespace is not explicitly set, the following command blatantly fails to find `x-metrics` namespace (assuming it doesn't exist in advance):

```
helm install x-metrics x-metrics/x-metrics --namespace crossplane-system --wait
```

The idea is to install the resources in the same namespace where we install the helm release, while still allowing customising the target namespace.