### PR TITLE
fix: log listing error

### DIFF
--- a/pkg/store/x_metric_store.go
+++ b/pkg/store/x_metric_store.go
@@ -51,9 +51,10 @@ func (s *XMetricsStore) init(ctx context.Context, client dynamic.Interface, name
 	log := log.FromContext(ctx)
 	o, err := client.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		log.Info("err listing")
+		log.Error(err, "err listing")
+	} else {
+		s.counter = len(o.Items)
 	}
-	s.counter = len(o.Items)
 }
 
 func (s *XMetricsStore) Add(obj interface{}) error {


### PR DESCRIPTION
Loggs an error if listing a resource is not possible while startup. 

Prevents crash described in #24 